### PR TITLE
feat(docker): add Dockerfile and render.yaml for API deployment on Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Dependencies (rebuilt inside Docker)
+node_modules
+dist
+
+# Nx and Angular caches
+.nx
+.angular
+
+# Git and CI
+.git
+.github
+.husky
+
+# Editor and tooling
+.vscode
+.idea
+*.log
+
+# Docs and dev tooling
+docs
+requests/
+
+# Secrets and local env — never bake into the image
+secrets/
+.env
+.env.*
+
+# Misc
+*.md
+coverage
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ Thumbs.db
 
 secrets/
 .env
+.env.docker
 requests/.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:24-alpine AS builder
+FROM node:24.14.1-alpine AS builder
 
 ENV NX_DAEMON=false
 
@@ -7,7 +7,7 @@ WORKDIR /app
 
 # Install deps first — layer cache: only reinstalls when lockfile changes
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --no-audit --no-fund
 
 # Copy the full workspace (Nx needs the monorepo root to resolve packages)
 COPY . .
@@ -19,7 +19,7 @@ RUN npx nx build api
 RUN npx nx run api:prune
 
 # Stage 2: Runtime
-FROM node:24-alpine AS runner
+FROM node:24.14.1-alpine AS runner
 
 ENV NODE_ENV=production
 
@@ -29,7 +29,7 @@ WORKDIR /app
 COPY --from=builder /app/dist/apps/api .
 
 # Install only production dependencies using the pruned lockfile
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --no-audit --no-fund
 
 EXPOSE 10000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Build
+FROM node:24-alpine AS builder
+
+ENV NX_DAEMON=false
+
+WORKDIR /app
+
+# Install deps first — layer cache: only reinstalls when lockfile changes
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy the full workspace (Nx needs the monorepo root to resolve packages)
+COPY . .
+
+# Build the API (production mode by default per project.json)
+RUN npx nx build api
+
+# Prune lockfile and copy local workspace modules for a minimal production install
+RUN npx nx run api:prune
+
+# Stage 2: Runtime
+FROM node:24-alpine AS runner
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+# Copy only the built output — includes main.js, package.json, package-lock.json, assets/, workspace_modules/
+COPY --from=builder /app/dist/apps/api .
+
+# Install only production dependencies using the pruned lockfile
+RUN npm ci --omit=dev
+
+EXPOSE 10000
+
+CMD ["node", "main.js"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,38 @@ To initialize the plugin in this project, run:
 
 ## 🐳 Running the API with Docker
 
+### Dev mode with Docker Compose (hot-reload)
+
+Make sure you have a `.env` file (copy from `.env.example` and fill in your values):
+
+```bash
+cp .env.example .env
+```
+
+Then start everything:
+
+```bash
+docker compose up
+```
+
+This starts MongoDB and the API together. The workspace is mounted into the container so file changes trigger a hot-reload automatically. The API is available at `http://localhost:3000/api`.
+
+> First run installs all `node_modules` inside the container — this takes a few minutes. Subsequent starts reuse the cached volume and are fast.
+
+To stop:
+
+```bash
+docker compose down
+```
+
+To also wipe the `node_modules` volume (e.g. after adding new dependencies):
+
+```bash
+docker compose down -v
+```
+
+---
+
 ### Build the image
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ Then start everything:
 docker compose up
 ```
 
-This starts MongoDB and the API together. The workspace is mounted into the container so file changes trigger a hot-reload automatically. The API is available at `http://localhost:3000/api`.
+This starts MongoDB, installs dependencies, and runs both the API and the Angular frontend with hot-reload.
 
-> First run installs all `node_modules` inside the container — this takes a few minutes. Subsequent starts reuse the cached volume and are fast.
+| Service  | URL                       |
+| -------- | ------------------------- |
+| Frontend | http://localhost:4200     |
+| API      | http://localhost:3000/api |
+
+> A `deps` service runs `npm ci` once into a shared volume, then exits. `api` and `frontend` wait for it to complete before starting. First run takes a few minutes; subsequent starts are fast.
 
 To stop:
 
@@ -43,11 +48,13 @@ To stop:
 docker compose down
 ```
 
-To also wipe the `node_modules` volume (e.g. after adding new dependencies):
+To also wipe the `node_modules` volume (e.g. after adding or removing npm packages):
 
 ```bash
-docker compose down -v
+docker compose down -v && docker compose up
 ```
+
+> **On Mac/Windows:** if Angular hot-reload doesn't pick up file changes, add `--poll 1000` to the frontend command in `docker-compose.yml` — inotify events can be unreliable over volume mounts on non-Linux hosts.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,23 +33,22 @@ First start MongoDB (already defined in `docker-compose.yml`):
 docker compose up -d mongo
 ```
 
-Then run the API, passing your environment variables. On **Mac/Windows** use `host.docker.internal` to reach services running on the host:
+Then create a `.env.docker` file from the example (it's gitignored):
 
 ```bash
-docker run --rm -p 10000:10000 \
-  -e MONGODB_URI="mongodb://host.docker.internal:27018/take-my-energy" \
-  -e JWT_SECRET="change-me" \
-  -e GOOGLE_CLIENT_ID="your-client-id" \
-  -e GOOGLE_CLIENT_SECRET="your-client-secret" \
-  -e GOOGLE_CALLBACK_URL="http://localhost:10000/api/auth/google/callback" \
-  -e FRONTEND_URL="http://localhost:4200" \
-  -e ADMIN_ALLOWLIST_EMAILS="you@example.com" \
-  -e RESEND_API_KEY="your-key" \
-  -e EMAIL_FROM="noreply@example.com" \
-  take-my-energy-api
+cp .env.example .env.docker
 ```
 
-On **Linux**, replace `host.docker.internal` with `172.17.0.1` (the default Docker bridge gateway) or use `--network host` instead of `-p 10000:10000`.
+Edit `.env.docker` and change `MONGODB_URI` so it points to your host machine instead of `localhost` (which inside a container refers to the container itself):
+
+- **Mac / Windows:** `MONGODB_URI=mongodb://host.docker.internal:27018/take-my-energy`
+- **Linux:** `MONGODB_URI=mongodb://172.17.0.1:27018/take-my-energy`
+
+Fill in the remaining values, then run:
+
+```bash
+docker run --rm -p 10000:10000 --env-file .env.docker take-my-energy-api
+```
 
 The API will be available at `http://localhost:10000/api`.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,44 @@ To initialize the plugin in this project, run:
 /ce-setup
 ```
 
+## 🐳 Running the API with Docker
+
+### Build the image
+
+```bash
+docker build -t take-my-energy-api .
+```
+
+### Run the container
+
+First start MongoDB (already defined in `docker-compose.yml`):
+
+```bash
+docker compose up -d mongo
+```
+
+Then run the API, passing your environment variables. On **Mac/Windows** use `host.docker.internal` to reach services running on the host:
+
+```bash
+docker run --rm -p 10000:10000 \
+  -e MONGODB_URI="mongodb://host.docker.internal:27018/take-my-energy" \
+  -e JWT_SECRET="change-me" \
+  -e GOOGLE_CLIENT_ID="your-client-id" \
+  -e GOOGLE_CLIENT_SECRET="your-client-secret" \
+  -e GOOGLE_CALLBACK_URL="http://localhost:10000/api/auth/google/callback" \
+  -e FRONTEND_URL="http://localhost:4200" \
+  -e ADMIN_ALLOWLIST_EMAILS="you@example.com" \
+  -e RESEND_API_KEY="your-key" \
+  -e EMAIL_FROM="noreply@example.com" \
+  take-my-energy-api
+```
+
+On **Linux**, replace `host.docker.internal` with `172.17.0.1` (the default Docker bridge gateway) or use `--network host` instead of `-p 10000:10000`.
+
+The API will be available at `http://localhost:10000/api`.
+
+---
+
 ## 🧠 Philosophy
 
 We shift from standard ad-hoc prompting to a structured, agent-driven workflow. We treat coding as a continuous loop where:

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -16,7 +16,7 @@ async function bootstrap() {
   app.useGlobalInterceptors(new LoggingInterceptor());
 
   const port = process.env['PORT'] || 3000;
-  await app.listen(port);
+  await app.listen(port, '0.0.0.0');
   Logger.log(`Application running on http://localhost:${port}/api`);
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,26 @@ services:
     volumes:
       - mongo_data:/data/db
 
+  api:
+    image: node:24.14.1-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      # Named volume keeps node_modules inside the container so host binaries
+      # (compiled for a different OS) don't shadow the container's installs
+      - api_node_modules:/app/node_modules
+    command: sh -c "npm ci --no-audit --no-fund && npx nx serve api"
+    env_file:
+      - .env
+    environment:
+      # Override the .env value so the API reaches mongo via the compose network
+      - MONGODB_URI=mongodb://mongo:27017/take-my-energy
+      - NX_DAEMON=false
+    ports:
+      - '3000:3000'
+    depends_on:
+      - mongo
+
 volumes:
   mongo_data:
+  api_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,26 +6,54 @@ services:
     volumes:
       - mongo_data:/data/db
 
+  # Installs node_modules once into a shared volume, then exits.
+  # api and frontend wait for this to complete before starting.
+  deps:
+    image: node:24.14.1-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - workspace_node_modules:/app/node_modules
+    command: npm ci --no-audit --no-fund
+
   api:
     image: node:24.14.1-alpine
     working_dir: /app
     volumes:
       - .:/app
-      # Named volume keeps node_modules inside the container so host binaries
-      # (compiled for a different OS) don't shadow the container's installs
-      - api_node_modules:/app/node_modules
-    command: sh -c "npm ci --no-audit --no-fund && npx nx serve api"
+      - workspace_node_modules:/app/node_modules
+    command: npx nx serve api
     env_file:
       - .env
     environment:
-      # Override the .env value so the API reaches mongo via the compose network
       - MONGODB_URI=mongodb://mongo:27017/take-my-energy
       - NX_DAEMON=false
     ports:
       - '3000:3000'
     depends_on:
-      - mongo
+      mongo:
+        condition: service_started
+      deps:
+        condition: service_completed_successfully
+
+  frontend:
+    image: node:24.14.1-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - workspace_node_modules:/app/node_modules
+    # --host 0.0.0.0 makes the Angular dev server reachable from outside the container
+    command: npx nx serve fiveOfHeart --host 0.0.0.0
+    env_file:
+      - .env
+    environment:
+      - NX_DAEMON=false
+    ports:
+      - '4200:4200'
+    depends_on:
+      deps:
+        condition: service_completed_successfully
 
 volumes:
   mongo_data:
-  api_node_modules:
+  workspace_node_modules:

--- a/docs/plans/2026-06-08-002-feat-dockerfile-render-deployment-plan.md
+++ b/docs/plans/2026-06-08-002-feat-dockerfile-render-deployment-plan.md
@@ -1,0 +1,236 @@
+---
+title: 'feat: Add Dockerfile and render.yaml for API deployment on Render'
+type: feat
+status: active
+date: 2026-06-08
+---
+
+# feat: Add Dockerfile and render.yaml for API deployment on Render
+
+## Summary
+
+Create a multi-stage `Dockerfile` that builds and packages the NestJS API inside Docker, a `.dockerignore` to keep the build context lean, a `render.yaml` infrastructure definition for version-controlled Render configuration, and a minor `main.ts` fix to bind explicitly to `0.0.0.0` as required by Render's load balancer.
+
+---
+
+## Problem Frame
+
+The NestJS API at `apps/api/` runs locally via `nx serve api` but has no containerized deployment path. Render's Docker runtime expects a `Dockerfile` that produces a runnable image — Render builds the image on each deploy, injects `PORT`, and routes traffic through its load balancer. Without an explicit `0.0.0.0` binding the app is unreachable inside the container. Without a `render.yaml` the service configuration lives only in the Render dashboard and is not version-controlled alongside the code.
+
+---
+
+## Requirements
+
+**Build and packaging**
+
+- R1. A multi-stage `Dockerfile` at the repo root builds the NestJS API in a builder stage using the existing Nx webpack build, then produces a slim runtime image containing only the pruned production dependencies and the compiled output.
+- R2. The Docker build context is the repo root (the Nx workspace requires access to the full monorepo during build).
+- R3. The runtime image uses Node 24 Alpine to match the project's `engines.node >= 24` constraint.
+- R4. A `.dockerignore` at the repo root excludes `node_modules`, `dist`, `.nx`, `.angular`, `.git`, secrets, and `.env` files from the build context.
+
+**Runtime behavior**
+
+- R5. The app binds to `0.0.0.0` so Render's load balancer can reach it.
+- R6. The app reads its port from `process.env.PORT`; Render injects `PORT=10000` at runtime.
+- R7. No secrets or environment variable values are baked into the Docker image; all runtime configuration is injected via Render's environment at container start.
+
+**Render configuration**
+
+- R8. A `render.yaml` at the repo root declares the web service with `runtime: docker`, pointing to the `Dockerfile` and the repo root as the build context.
+- R9. All secrets (MongoDB URI, JWT secret, Google OAuth credentials, Resend API key) use `sync: false` in `render.yaml` so their values are set in the Render dashboard and never committed to the repo.
+- R10. `render.yaml` includes a `buildFilter` so Render only triggers a new build when files relevant to the API change (not frontend-only changes).
+
+---
+
+## Key Technical Decisions
+
+- **Multi-stage build using Nx prune targets**: The builder stage runs `npx nx build api` (webpack bundle into `dist/apps/api/`) followed by `npx nx run api:prune` (which runs `prune-lockfile` + `copy-workspace-modules` in sequence). This produces a `package.json` and `package-lock.json` scoped to actual runtime dependencies, plus a `workspace_modules/` directory with any local libs. The runtime stage copies only `dist/apps/api/`, runs `npm ci --omit=dev`, and starts `node main.js`. This avoids shipping the full 1.2 GB monorepo `node_modules` into the image.
+
+- **`NX_DAEMON=false` in the builder stage**: The Nx daemon is a background process that provides project-graph caching for the local dev experience. Inside Docker there is no running daemon and no socket to connect to; setting `NX_DAEMON=false` prevents Nx from timing out waiting for a daemon connection and falls back cleanly to in-process graph resolution.
+
+- **`render.yaml` secrets use `sync: false` (not `generateValue`)**: All sensitive values (JWT secret, OAuth credentials, DB URI) are operator-supplied, not generated. `sync: false` tells Render to expect the value to be set manually in the dashboard — it omits the field from the YAML so the secret never touches version control, while still appearing in the service's environment variable list.
+
+- **Dockerfile at repo root, not `apps/api/`**: The Nx build toolchain resolves workspace package paths relative to the root. Placing the Dockerfile at the root and using `.` as the Docker context gives the builder stage access to the full monorepo without any path rewriting.
+
+- **`0.0.0.0` binding explicitly in `main.ts`**: NestJS's `app.listen(port)` with no host argument resolves to the OS default, which in some container configurations maps to `127.0.0.1`. Render's docs explicitly require `0.0.0.0`. Passing `'0.0.0.0'` as the second argument to `app.listen()` is the safe, portable fix.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  subgraph builder["Stage 1 — builder (node:24-alpine)"]
+    A[COPY package.json + package-lock.json] --> B[npm ci]
+    B --> C[COPY full workspace]
+    C --> D[npx nx build api\nwebpack → dist/apps/api/main.js]
+    D --> E[npx nx run api:prune\nprune-lockfile + copy-workspace-modules]
+  end
+
+  subgraph runner["Stage 2 — runner (node:24-alpine)"]
+    F["COPY --from=builder dist/apps/api → /app\n(main.js · package.json · package-lock.json · workspace_modules/)"]
+    F --> G[npm ci --omit=dev]
+    G --> H[CMD: node main.js]
+  end
+
+  E --> F
+
+  subgraph render["Render platform"]
+    H --> I["PORT=10000 injected\nRuntime env vars injected\nLoad balancer → 0.0.0.0:10000"]
+  end
+```
+
+---
+
+## Implementation Units
+
+### U1. Create `.dockerignore`
+
+**Goal:** Exclude large, irrelevant, or sensitive directories from the Docker build context so the build is fast and no secrets reach the image.
+
+**Requirements:** R4, R7
+
+**Dependencies:** none
+
+**Files:**
+
+- `.dockerignore` _(create)_
+
+**Approach:** Exclude `node_modules` and `dist` (rebuilt inside Docker), `.nx` and `.angular` (caches), `.git` and `.github`, `.husky`, `docs`, `requests/`, `secrets/`, all `.env` and `.env.*` files, and common log/temp patterns. The `apps/fiveOfHeart/` frontend source is large but needed in context since `COPY . .` must include `package.json` and any shared `libs/` — so exclude only the frontend's compiled artifacts (`.angular/`), not the source.
+
+**Test scenarios:**
+
+- Test expectation: none — `.dockerignore` has no runtime behavior to assert. Verified by the `docker build` in U2 completing without sending `node_modules/` in the context (visible from build output "Sending build context" size being reasonable).
+
+**Verification:** `docker build` in U2 succeeds without timing out on context upload; no `.env` values appear in the image.
+
+---
+
+### U2. Create multi-stage `Dockerfile`
+
+**Goal:** Produce a runnable, minimal Docker image for the NestJS API using a two-stage build that isolates build tooling from the production runtime.
+
+**Requirements:** R1, R2, R3, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+
+- `Dockerfile` _(create)_
+
+**Approach:**
+
+Builder stage (`node:24-alpine AS builder`):
+
+- Set `NX_DAEMON=false` to prevent daemon connection attempts
+- Copy `package.json` and `package-lock.json` first (layer cache: deps only reinstall when the lockfile changes)
+- Run `npm ci` to install all workspace dependencies
+- Copy the full workspace (`COPY . .`)
+- Run `npx nx build api` (webpack, production mode by default per `project.json`)
+- Run `npx nx run api:prune` to generate the pruned lockfile and copy workspace modules
+
+Runtime stage (`node:24-alpine AS runner`):
+
+- Set `NODE_ENV=production`
+- Copy `dist/apps/api/` into `/app` — this includes `main.js`, `package.json`, `package-lock.json`, and `workspace_modules/`
+- Run `npm ci --omit=dev` to install only production dependencies using the pruned lockfile
+- `EXPOSE 10000` (advisory; Render detects the port from `PORT` env var)
+- `CMD ["node", "main.js"]`
+
+**Patterns to follow:** Nx's own `setup-docker` generator template at `node_modules/@nx/node/src/generators/setup-docker/files/Dockerfile__tmpl__` (used as reference; the multi-stage approach here extends its pattern with a dedicated builder stage).
+
+**Test scenarios:**
+
+- Happy path: `docker build -t take-my-energy-api .` completes without error; `docker run -e PORT=10000 -e MONGODB_URI=<test-uri> … -p 10000:10000 take-my-energy-api` starts the server and `curl http://localhost:10000/api` returns a response (not a connection refused).
+- Build cache: Running `docker build` a second time without code changes reuses all layers from the dependency install step onward.
+- No secrets in image: Inspecting the image with `docker history take-my-energy-api` shows no env var values baked in beyond `NODE_ENV=production`.
+
+**Verification:** Image builds cleanly, the container starts and the API is reachable on the configured port.
+
+---
+
+### U3. Bind API to `0.0.0.0` in `main.ts`
+
+**Goal:** Ensure the NestJS app listens on all network interfaces so Render's load balancer can route traffic to the container.
+
+**Requirements:** R5, R6
+
+**Dependencies:** none
+
+**Files:**
+
+- `apps/api/src/main.ts` _(modify)_
+
+**Approach:** Change `app.listen(port)` to `app.listen(port, '0.0.0.0')`. No other changes. The `port` variable already reads from `process.env['PORT'] || 3000`, so Render's injected `PORT=10000` is respected automatically.
+
+**Test scenarios:**
+
+- Happy path: In the Docker container from U2, the process binds on `0.0.0.0:10000` (visible in startup log or via `ss -tlnp`); requests from outside the container succeed.
+- Local dev unchanged: Running `nx serve api` locally still starts on port 3000 and is reachable on `localhost:3000/api`.
+
+**Verification:** `docker run … take-my-energy-api` logs `Application running on http://localhost:10000/api`; `curl` from the host succeeds.
+
+---
+
+### U4. Create `render.yaml`
+
+**Goal:** Version-control the Render service definition so the deployment configuration is reproducible and reviewable alongside the code.
+
+**Requirements:** R8, R9, R10
+
+**Dependencies:** U2 (Dockerfile must exist for the `dockerfilePath` reference to be valid)
+
+**Files:**
+
+- `render.yaml` _(create)_
+
+**Approach:**
+
+- `type: web`, `runtime: docker` — Render builds from the `Dockerfile`
+- `dockerfilePath: ./Dockerfile`, `dockerContext: .` — root Dockerfile, full repo context
+- `buildFilter.paths` — include `apps/api/**`, `libs/**`, `package.json`, `package-lock.json`, `Dockerfile`, `.dockerignore`; exclude frontend paths so Angular-only changes do not trigger an API redeploy
+- `plan: starter` — the lowest paid tier (upgrade in the dashboard for auto-sleep-free behavior); the `free` tier sleeps after inactivity
+- `envVars`: set `NODE_ENV=production` as a plain value; all other vars from `.env.example` use `sync: false` so values are entered in the Render dashboard and never committed
+
+**Patterns to follow:** Render Blueprint Spec (see Sources); `sync: false` is the required pattern for any credential that must not appear in version control.
+
+**Test scenarios:**
+
+- Test expectation: none — `render.yaml` is declarative config with no executable logic. Verified manually by connecting the repo in the Render dashboard, confirming the service is detected from `render.yaml`, and confirming the env var fields appear as "not synced" (prompting for values).
+
+**Verification:** The Render dashboard detects the `render.yaml` blueprint on first connection; all secret env vars show as unset/awaiting values rather than pre-filled.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- **Health check endpoint** — `render.yaml` omits `healthCheckPath` because the API has no `/health` route. Adding `GET /api/health` (returning `{ status: "ok" }`) would enable Render's HTTP health probe for faster zero-downtime deploys.
+- **Autoscaling** — `render.yaml` uses a fixed `numInstances: 1`. Scaling configuration (`scaling.minInstances`, `scaling.targetCPUPercent`) requires a Pro plan and is left for when traffic warrants it.
+- **Preview environments** — `previews.generation: automatic` would spin up isolated environments per PR; deferred until the team adopts PR-based review workflows.
+
+### Out of scope
+
+- Dockerizing or deploying the Angular frontend (`apps/fiveOfHeart/`) — it is already deployed to Vercel via `vercel.json`.
+- MongoDB hosting — the API connects to an external MongoDB instance (Atlas or similar); no database infrastructure is provisioned here.
+- CI/CD pipeline changes — no GitHub Actions workflow is added; Render's own build trigger from `render.yaml` handles deploys on push.
+
+---
+
+## Risks & Dependencies
+
+- **Nx workspace in Docker build time** — The full `npm ci` inside Docker installs all 1.2 GB of dependencies (including Angular devDeps) before building. Build times will be 3-5 minutes on first run. Subsequent builds reuse the layer cache unless `package-lock.json` changes. Mitigation: avoid bumping deps unnecessarily; consider a `.npmrc` with `--prefer-offline` if caching is configured on Render.
+- **Render free tier auto-sleep** — The `free` plan sleeps after 15 minutes of inactivity. `plan: starter` is specified in `render.yaml` to avoid this; confirm the billing plan in the Render dashboard matches.
+- **`NX_DAEMON=false` in future Nx versions** — This flag disables the daemon. Nx may change how this env var is named or interpreted. If a future Nx upgrade changes the daemon opt-out mechanism, the Dockerfile builder stage may need updating.
+
+---
+
+## Sources & Research
+
+- Render Docker deployment docs: bind to `0.0.0.0`, `PORT=10000` default, multi-stage build support, BuildKit layer caching — [render.com/docs/docker](https://render.com/docs/docker)
+- Render Blueprint Spec: `render.yaml` field reference, `sync: false` for secrets, `buildFilter`, Docker-specific fields (`dockerfilePath`, `dockerContext`, `dockerCommand`) — [render.com/docs/blueprint-spec](https://render.com/docs/blueprint-spec)
+- Nx prune targets: `prune-lockfile` and `copy-workspace-modules` executor contract — `apps/api/project.json` (targets: `prune-lockfile`, `copy-workspace-modules`, `prune`)
+- Nx Docker template reference: `node_modules/@nx/node/src/generators/setup-docker/files/Dockerfile__tmpl__`
+- App entry point and port handling: `apps/api/src/main.ts`
+- Environment variables: `apps/api/src/main.ts`, `.env.example`

--- a/docs/plans/2026-06-08-002-feat-dockerfile-render-deployment-plan.md
+++ b/docs/plans/2026-06-08-002-feat-dockerfile-render-deployment-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Add Dockerfile and render.yaml for API deployment on Render'
 type: feat
-status: active
+status: completed
 date: 2026-06-08
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,40 @@
+services:
+  - name: take-my-energy-api
+    type: web
+    runtime: docker
+    region: oregon
+    plan: starter
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    # Only trigger a new build when API-relevant files change
+    buildFilter:
+      paths:
+        - apps/api/**
+        - libs/**
+        - package.json
+        - package-lock.json
+        - Dockerfile
+        - .dockerignore
+    envVars:
+      - key: NODE_ENV
+        value: production
+      # Secrets — set values in the Render dashboard, never committed here
+      - key: MONGODB_URI
+        sync: false
+      - key: JWT_SECRET
+        sync: false
+      - key: GOOGLE_CLIENT_ID
+        sync: false
+      - key: GOOGLE_CLIENT_SECRET
+        sync: false
+      - key: GOOGLE_CALLBACK_URL
+        sync: false
+      - key: ADMIN_ALLOWLIST_EMAILS
+        sync: false
+      - key: RESEND_API_KEY
+        sync: false
+      - key: EMAIL_FROM
+        sync: false
+      - key: FRONTEND_URL
+        sync: false
+      # PORT is intentionally omitted — Render injects it automatically (default: 10000)

--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,8 @@ services:
   - name: take-my-energy-api
     type: web
     runtime: docker
-    region: oregon
-    plan: starter
+    region: frankfurt
+    plan: free # sleeps after 15 min of inactivity; upgrade to starter to disable auto-sleep
     dockerfilePath: ./Dockerfile
     dockerContext: .
     # Only trigger a new build when API-relevant files change
@@ -15,6 +15,7 @@ services:
         - package-lock.json
         - Dockerfile
         - .dockerignore
+        - render.yaml
     envVars:
       - key: NODE_ENV
         value: production

--- a/requests/auth.http
+++ b/requests/auth.http
@@ -20,6 +20,7 @@ GET {{BASE_URL}}/api/auth/google
 
 # Verify the obtained token works by calling a protected endpoint
 # @name verifyToken
-GET {{BASE_URL}}/api/catalog
+GET {{BASE_URL}}/api/gift-cards
 Authorization: Bearer {{ACCESS_TOKEN}}
+
 ?? status 200


### PR DESCRIPTION
## Summary

- Adds a multi-stage `Dockerfile` that builds the NestJS API inside Docker using the Nx webpack build + prune pipeline, then produces a slim runtime image with only production dependencies
- Adds `.dockerignore` to keep the build context lean and prevent secrets from reaching the image
- Adds `render.yaml` for version-controlled Render service configuration
- Fixes `main.ts` to bind on `0.0.0.0` as required by Render's load balancer

## Key decisions

- **Multi-stage build with Nx prune**: builder stage runs `nx build api` + `nx run api:prune` (prune-lockfile + copy-workspace-modules), runtime stage copies `dist/apps/api/` and runs `npm ci --omit=dev` — avoids shipping the full monorepo node_modules
- **`NX_DAEMON=false`**: prevents daemon connection timeout in Docker where no daemon process is running
- **`frankfurt` region**: closest Render region to France
- **`free` plan**: sleeps after 15 min of inactivity; comment in `render.yaml` explains how to upgrade
- **`sync: false` for all secrets**: values are entered in the Render dashboard and never committed to the repo
- **Node 24.14.1-alpine**: pinned tag for reproducible builds (matches local `node --version`)

## Test plan

- [ ] All 32 API tests pass (`nx test api`)
- [ ] `docker build -t take-my-energy-api .` completes without error
- [ ] `docker run -e PORT=10000 -e MONGODB_URI=<uri> … -p 10000:10000 take-my-energy-api` starts and `curl http://localhost:10000/api` responds
- [ ] Render dashboard detects the `render.yaml` blueprint on repo connect
- [ ] All secret env vars show as unset/awaiting values in the dashboard

## Post-Deploy Monitoring & Validation

- **Render dashboard logs**: check build logs for `npm ci` errors or Nx build failures on first deploy
- **Healthy signal**: container starts and logs `Application running on http://localhost:10000/api`
- **Failure signal**: Render health check fails (TCP) or deploy times out — check build logs for `NX_DAEMON` timeout or missing env vars
- **Validation**: hit `https://<service>.onrender.com/api` after first deploy; update `GOOGLE_CALLBACK_URL` in Google Cloud Console to the Render service URL before testing OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)